### PR TITLE
Add tyre stint series decoding tests

### DIFF
--- a/Sources/LiveTimingKit/Models/TimingData.swift
+++ b/Sources/LiveTimingKit/Models/TimingData.swift
@@ -1,11 +1,15 @@
 import Foundation
 
 public struct TimingData: Codable, Sendable {
-    public var lines: [String: TimingDataLine]
+    public var lines: [String: TimingDataLine] = [:]
     public var withheld: Bool?
     public var kf: Bool?
 
-    public init(lines: [String: TimingDataLine], withheld: Bool? = nil, kf: Bool? = nil) {
+    public init(
+        lines: [String: TimingDataLine] = [:], 
+        withheld: Bool? = nil, 
+        kf: Bool? = nil
+    ) {
         self.lines = lines
         self.withheld = withheld
         self.kf = kf

--- a/Tests/LiveTimingKitKitTests/TyreStintSeriesDecodingTests.swift
+++ b/Tests/LiveTimingKitKitTests/TyreStintSeriesDecodingTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+@testable import LiveTimingKit
+
+final class TyreStintSeriesDecodingTests: XCTestCase {
+    func testDecodesArrayStints() throws {
+        let json = """
+        {
+          "Stints": {
+            "31": [
+              {
+                "Compound": "HARD",
+                "New": "true",
+                "TyresNotChanged": "0",
+                "TotalLaps": 1,
+                "StartLaps": 0
+              }
+            ]
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(TyreStintSeries.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.stints["31"]?.count, 1)
+        XCTAssertEqual(decoded.stints["31"]?.first?.compound, .hard)
+        XCTAssertEqual(decoded.stints["31"]?.first?.startLaps, 0)
+    }
+
+    func testDecodesDictionaryStintsInNumericOrder() throws {
+        let json = """
+        {
+          "Stints": {
+            "31": {
+              "1": {
+                "Compound": "MEDIUM",
+                "New": "true",
+                "TyresNotChanged": "0",
+                "TotalLaps": 3,
+                "StartLaps": 3
+              },
+              "0": {
+                "Compound": "HARD",
+                "New": "true",
+                "TyresNotChanged": "0",
+                "TotalLaps": 2,
+                "StartLaps": 0
+              }
+            }
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(TyreStintSeries.self, from: Data(json.utf8))
+        let compounds = decoded.stints["31"]?.map(\.compound)
+        let startLaps = decoded.stints["31"]?.map(\.startLaps)
+
+        XCTAssertEqual(compounds, [.hard, .medium])
+        XCTAssertEqual(startLaps, [0, 3])
+    }
+}


### PR DESCRIPTION
Summary
- add unit tests verifying `TyreStintSeries` decodes array- and dictionary-based stints and maintains numeric order
- give `TimingData` a default empty lines dictionary so it can be initialized without data when decoding

Testing
- Not run (not requested)