### PR TITLE
Define lifecycle contract in LiveTimingService

### DIFF
--- a/Sources/LiveTimingKit/Services/LiveTimingService.swift
+++ b/Sources/LiveTimingKit/Services/LiveTimingService.swift
@@ -219,4 +219,6 @@
 
 public protocol LiveTimingService: Actor {
     var eventProcessor: LiveTimingEventProcessor { get async }
+    func stream() async -> AsyncStream<LiveTimingState>
+    func stop() async
 }

--- a/Sources/LiveTimingKit/Services/LiveTimingSignalRClient.swift
+++ b/Sources/LiveTimingKit/Services/LiveTimingSignalRClient.swift
@@ -58,4 +58,10 @@ public actor LiveTimingSignalRClient: LiveTimingService {
             }
         }
     }
+
+    public func stop() async {
+        await connection.stop()
+        continuation?.finish()
+        continuation = nil
+    }
 }


### PR DESCRIPTION
## Summary
- expand LiveTimingService to include stream and stop lifecycle methods
- make LiveTimingSignalRClient conform explicitly with a public stop() implementation
- keep public API contract aligned with runtime behavior

## Validation
- swift build
- swift test