### PR TITLE
Expose fields on public model types

### DIFF
--- a/Sources/LiveTimingKit/Models/Heartbeat.swift
+++ b/Sources/LiveTimingKit/Models/Heartbeat.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public struct Heartbeat: Codable, Sendable {
-    let utc: String
-    let kf: Bool?
+    public let utc: String
+    public let kf: Bool?
 
     enum CodingKeys: String, CodingKey {
         case utc = "Utc"

--- a/Sources/LiveTimingKit/Models/TimingStats.swift
+++ b/Sources/LiveTimingKit/Models/TimingStats.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 public struct TimingStats: Codable, Sendable {
-    let withheld: Bool?
+    public let withheld: Bool?
     var lines: [String: TimingStatsLine]
-    let sessionType: String?
-    let kf: Bool?
+    public let sessionType: String?
+    public let kf: Bool?
 
     enum CodingKeys: String, CodingKey {
         case withheld = "Withheld"


### PR DESCRIPTION
## Summary
- make Heartbeat fields publicly readable
- make key TimingStats metadata fields publicly readable
- align public type visibility with a usable package API surface

## Validation
- swift build
- swift test