### PR TITLE
Pin SignalR dependency and remove unused Vapor

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,51 +1,6 @@
 {
-  "originHash" : "7160f4f4ec0026a08e339d146a8f7dd8d132fa5a7ef99140dc2860ebbf046971",
+  "originHash" : "8e52f27add123a6987b097d85ceab6cb6a2b7826c42847e45e4e21d08a171604",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "60235983163d040f343a489f7e2e77c1918a8bd9",
-        "version" : "1.26.1"
-      }
-    },
-    {
-      "identity" : "async-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/async-kit.git",
-      "state" : {
-        "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
-        "version" : "1.20.0"
-      }
-    },
-    {
-      "identity" : "console-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/console-kit.git",
-      "state" : {
-        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
-        "version" : "4.15.2"
-      }
-    },
-    {
-      "identity" : "multipart-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/multipart-kit.git",
-      "state" : {
-        "revision" : "3498e60218e6003894ff95192d756e238c01f44e",
-        "version" : "4.7.1"
-      }
-    },
-    {
-      "identity" : "routing-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/routing-kit.git",
-      "state" : {
-        "revision" : "93f7222c8e195cbad39fafb5a0e4cc85a8def7ea",
-        "version" : "4.9.2"
-      }
-    },
     {
       "identity" : "signalr-client-swift",
       "kind" : "remoteSourceControl",
@@ -119,15 +74,6 @@
       }
     },
     {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "a64a0abc2530f767af15dd88dda7f64d5f1ff9de",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-http-structured-headers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
@@ -152,15 +98,6 @@
       "state" : {
         "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
         "version" : "1.6.3"
-      }
-    },
-    {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "4c83e1cdf4ba538ef6e43a9bbd0bcc33a0ca46e3",
-        "version" : "2.7.0"
       }
     },
     {
@@ -218,15 +155,6 @@
       }
     },
     {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "8946c930cae601452149e45d31d8ddfac973c3c7",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "swift-service-lifecycle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
@@ -242,15 +170,6 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "vapor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/vapor.git",
-      "state" : {
-        "revision" : "4014016aad591a120f244f9b9e8a57252b7e62b4",
-        "version" : "4.115.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,15 @@ let package = Package(
             targets: ["LiveTimingKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
-        //.package(path: "../../signalr-client-swift")
-        .package(url: "https://github.com/Arafo/signalr-client-swift", branch: "dev")
+        .package(
+            url: "https://github.com/Arafo/signalr-client-swift",
+            revision: "7bba94f88d6af74e91f4ebefdab8062c2666747b"
+        )
     ],
     targets: [
         .target(
             name: "LiveTimingKit",
             dependencies: [
-                .product(name: "Vapor", package: "vapor"),
                 .product(name: "SignalRClient", package: "signalr-client-swift")
             ]),
         .testTarget(

--- a/Sources/LiveTimingKit/Services/EventProcessor.swift
+++ b/Sources/LiveTimingKit/Services/EventProcessor.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NIOCore
 
 public protocol LiveTimingEventProcessor: Actor {
     var state: LiveTimingState { get async }


### PR DESCRIPTION
## Summary
- replace branch-based SignalR dependency with a pinned revision
- remove unused Vapor package and target product dependency
- remove now-unneeded NIOCore import in EventProcessor

## Validation
- swift build
- swift test