### PR TITLE
Emit state snapshot when subscribing to SignalR events

### DIFF
--- a/Sources/LiveTimingKit/Services/LiveTimingSignalRClient.swift
+++ b/Sources/LiveTimingKit/Services/LiveTimingSignalRClient.swift
@@ -89,6 +89,7 @@ public actor LiveTimingSignalRClient: LiveTimingService {
                                 "meeting_key": .string(fullSnapshot.sessionInfo?.meeting?.key.map(String.init) ?? "nil")
                             ]
                         )
+                        await continuation.yield(self.eventProcessor.state)
                     } catch {
                         self.logger.error(
                             "Failed to parse SignalR subscribe snapshot.",


### PR DESCRIPTION
**Summary**
- yield current `eventProcessor` state immediately after emitting the subscribe snapshot to keep downstream observers informed

**Testing**
- Not run (not requested)