### PR TITLE
Use SignalR negotiate cookie branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "13591ec996e65d941a64f2c8ae20078981330837cb2105bbe306922cc0929832",
+  "originHash" : "4739e138127f069c585ccc236a4c9c1cd548fecbffbdaecb57405b0efa63881e",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -15,7 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Arafo/signalr-client-swift",
       "state" : {
-        "revision" : "8b2988b954b6ab2f70070564dd8ee79c1b9fd98d"
+        "branch" : "feature/preserve-negotiate-cookies",
+        "revision" : "6c5d1b638b9535f7d5d14add08301f34794f8017"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4739e138127f069c585ccc236a4c9c1cd548fecbffbdaecb57405b0efa63881e",
+  "originHash" : "0a514288a6ec2aafd55f5530109d5753c91ba658b9573805a588f1478a6287ab",
   "pins" : [
     {
       "identity" : "bitbytedata",
@@ -15,8 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Arafo/signalr-client-swift",
       "state" : {
-        "branch" : "feature/preserve-negotiate-cookies",
-        "revision" : "6c5d1b638b9535f7d5d14add08301f34794f8017"
+        "revision" : "e1b39c0ff5830491f613502a91e853c6a47de205"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Arafo/signalr-client-swift",
-            revision: "8b2988b954b6ab2f70070564dd8ee79c1b9fd98d"
+            branch: "feature/preserve-negotiate-cookies"
         ),
         .package(
             url: "https://github.com/apple/swift-log.git",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Arafo/signalr-client-swift",
-            branch: "feature/preserve-negotiate-cookies"
+            revision: "e1b39c0ff5830491f613502a91e853c6a47de205"
         ),
         .package(
             url: "https://github.com/apple/swift-log.git",


### PR DESCRIPTION
## Summary
- point LiveTimingKit at the SignalRClient branch that preserves negotiate cookies
- update Package.resolved for that branch revision

## Testing
- swift test